### PR TITLE
add uvicorn workers parameters

### DIFF
--- a/fastapi.Dockerfile
+++ b/fastapi.Dockerfile
@@ -6,4 +6,9 @@ COPY requirements-fastapi.txt requirements.txt
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 
-CMD ["uvicorn", "api.server:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "0"]
+EXPOSE 8080
+
+COPY ./fastapi_start.sh /app/start.sh
+RUN chmod +x /app/start.sh
+
+CMD ./start.sh

--- a/fastapi_start.sh
+++ b/fastapi_start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [[ ! -v NUMBER_OF_WORKERS ]]; then
+    export NUMBER_OF_WORKERS=$(grep -c processor /proc/cpuinfo)
+fi
+
+uvicorn api.server:app --host 0.0.0.0 --port 8000 --workers ${NUMBER_OF_WORKERS}


### PR DESCRIPTION
Docker 컨테이너 실행시 환경변수를 통해 uvicorn worker 개수를 지정할 수 있도록 하였습니다.
지정하지 않으면 CPU코어 개수로 지정됩니다.
ex)
```shell
docker run ... -e NUMBER_OF_WORKERS 4
```